### PR TITLE
Add multi-level ordered list example

### DIFF
--- a/ordered-list-example.html
+++ b/ordered-list-example.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>多層次條列示範</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        body {
+            background-color: #f4f6f8;
+        }
+        pre.whitespace-pre-wrap {
+            font-family: 'Noto Sans TC', 'PingFang TC', 'Microsoft JhengHei', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            line-height: 1.85;
+            letter-spacing: 0.02em;
+        }
+        mark {
+            background: linear-gradient(120deg, #fde68a 0%, #fcd34d 100%);
+            padding: 0 0.15em;
+            border-radius: 0.25rem;
+        }
+    </style>
+</head>
+<body class="min-h-screen flex items-center justify-center p-6">
+    <div class="max-w-4xl w-full bg-white shadow-xl rounded-2xl border border-slate-200 p-8">
+        <h1 class="text-2xl font-semibold text-slate-900 mb-6 tracking-wide text-center">多層次有序條列示意</h1>
+        <pre class="whitespace-pre-wrap font-sans text-slate-800 bg-slate-50 border border-slate-200 rounded-xl p-6">
+五、議程總覽：
+    ➝1. 前期協調事項：
+        ➝2. <mark>溝通重點</mark>：
+            ➝3. 與教學醫院確認臨床導師名單：
+                · 回報時間為 6 月底前，需提供完整聯絡方式。
+                · 同步備查教學資歷，作為分組配對依據。
+            ➝4. 實習場域資源盤點：
+                · 評估模擬教室儀器狀態，完成保養與更新清單。
+                · 列管跨院借用需求，統一由行政窗口聯繫。
+        ➝2. 行政支援配置：
+            ➝3. 場地與設備準備：
+                · 會議室需配置雙螢幕錄影系統，會前 2 天完成測試。
+                · 整理學員簽到資料表，預先匯入電子簽到平台。
+            ➝4. 文件與資料彙整：
+                · 建立雲端資料夾，集中上傳報告簡報與議程檔案。
+                · 以 <mark>版本控制</mark> 表格標註最新修訂日期與負責人。
+    ➝2. 會議進程安排：
+        ➝3. 開場與前次追蹤：
+            ➝4. 主席綜整重點：
+                · 5 分鐘回顧待辦事項完成度，強調未決議題。
+                · 公布跨科協作時程，確認各組負責窗口。
+            ➝5. 組別動態報告：
+                · 每組 8 分鐘口頭報告，2 分鐘現場提問。
+                · 紀錄重點問題，納入會後追蹤清單。
+        ➝3. 專題討論與決策：
+            ➝4. 課程調整提案：
+                · 評估新生導向課程時間分配，列出三種替代方案。
+                · 針對臨床實作需求，分析師資與設備負荷。
+            ➝5. 支援資源擴充：
+                · 規畫線上資源庫架構，蒐集示範教案。
+                · 邀請教學顧問擔任審稿，訂定審查流程。
+    ➝3. 後續追蹤：
+        ➝4. 會議紀錄撰寫：
+            ➝5. 初稿產出時程：
+                · 會後 48 小時內完成初稿，寄送全體委員核閱。
+                · 標示需回覆項目，限期 3 個工作天內回報。
+            ➝6. 行動項目管理：
+                · 依條列建立看板，指派責任人與截止日。
+                · 每週五更新進度，統一於例會前彙整。
+        ➝4. 成果分享與回饋：
+            ➝5. 內部成效盤點：
+                · 6 月 15 日前彙整問卷，向院務會報告執行情況。
+                · 依指標檢視教學品質，提出下一季改善目標。
+            ➝6. 對外交流規畫：
+                · 與合作醫學中心分享案例，安排暑期見習。
+                · 製作雙語摘要，供國際交流簡報使用。
+        </pre>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone HTML example demonstrating a multi-level ordered list with preserved indentation
- style the content with Tailwind CSS, Chinese-friendly fonts, and highlighted keywords while keeping alignment stable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d92884df908321962f12aeda3a64c4