### PR TITLE
Add Tailwind-styled meeting record list page

### DIFF
--- a/meeting-record-list.html
+++ b/meeting-record-list.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>會議紀錄清單</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        body {
+            font-family: 'Noto Sans TC', sans-serif;
+        }
+    </style>
+</head>
+<body class="bg-slate-100 min-h-screen py-10">
+    <main class="max-w-4xl mx-auto space-y-8">
+        <header class="text-center">
+            <h1 class="text-3xl font-bold text-slate-800">會議紀錄清單</h1>
+            <p class="text-slate-500 mt-2">依月份由新到舊排列，快速檢視歷次會議內容</p>
+        </header>
+
+        <!-- 九月 -->
+        <section class="bg-white shadow-lg rounded-xl border border-slate-200 overflow-hidden">
+            <div class="bg-sky-600 text-white px-6 py-4">
+                <h2 class="text-2xl font-semibold">九月</h2>
+                <p class="text-sky-100 text-sm mt-1">最新會議紀錄</p>
+            </div>
+            <div class="px-6 py-6 space-y-4">
+                <article class="rounded-lg border border-slate-200 bg-slate-50 p-4 shadow-sm">
+                    <header class="flex items-center justify-between">
+                        <h3 class="text-lg font-medium text-slate-800">教研室月會</h3>
+                        <span class="text-sm text-slate-500">2024/09/18</span>
+                    </header>
+                    <p class="mt-2 text-slate-600">討論本年度教師進修計畫與最新課程調整安排。</p>
+                    <footer class="mt-3 flex flex-wrap gap-2 text-sm text-slate-500">
+                        <span class="inline-flex items-center gap-1 rounded-full bg-sky-100 px-3 py-1 text-sky-700">#教學發展</span>
+                        <span class="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-3 py-1 text-emerald-700">#課程設計</span>
+                    </footer>
+                </article>
+                <article class="rounded-lg border border-slate-200 bg-slate-50 p-4 shadow-sm">
+                    <header class="flex items-center justify-between">
+                        <h3 class="text-lg font-medium text-slate-800">資訊委員會臨時會</h3>
+                        <span class="text-sm text-slate-500">2024/09/05</span>
+                    </header>
+                    <p class="mt-2 text-slate-600">確認新系統導入時間表及跨部門合作事宜。</p>
+                    <footer class="mt-3 flex flex-wrap gap-2 text-sm text-slate-500">
+                        <span class="inline-flex items-center gap-1 rounded-full bg-violet-100 px-3 py-1 text-violet-700">#系統導入</span>
+                        <span class="inline-flex items-center gap-1 rounded-full bg-amber-100 px-3 py-1 text-amber-700">#跨部門</span>
+                    </footer>
+                </article>
+            </div>
+        </section>
+
+        <!-- 八月 -->
+        <section class="bg-white shadow-lg rounded-xl border border-slate-200 overflow-hidden">
+            <div class="bg-indigo-600 text-white px-6 py-4">
+                <h2 class="text-2xl font-semibold">八月</h2>
+                <p class="text-indigo-100 text-sm mt-1">近期完成</p>
+            </div>
+            <div class="px-6 py-6 space-y-4">
+                <article class="rounded-lg border border-slate-200 bg-slate-50 p-4 shadow-sm">
+                    <header class="flex items-center justify-between">
+                        <h3 class="text-lg font-medium text-slate-800">校務發展會議</h3>
+                        <span class="text-sm text-slate-500">2024/08/22</span>
+                    </header>
+                    <p class="mt-2 text-slate-600">審視下一年度校務願景與重點建設項目。</p>
+                    <footer class="mt-3 flex flex-wrap gap-2 text-sm text-slate-500">
+                        <span class="inline-flex items-center gap-1 rounded-full bg-rose-100 px-3 py-1 text-rose-700">#校務規劃</span>
+                        <span class="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-3 py-1 text-emerald-700">#資源配置</span>
+                    </footer>
+                </article>
+            </div>
+        </section>
+
+        <!-- 七月 -->
+        <section class="bg-white shadow-lg rounded-xl border border-slate-200 overflow-hidden">
+            <div class="bg-emerald-600 text-white px-6 py-4">
+                <h2 class="text-2xl font-semibold">七月</h2>
+                <p class="text-emerald-100 text-sm mt-1">暑期議程</p>
+            </div>
+            <div class="px-6 py-6 space-y-4">
+                <article class="rounded-lg border border-slate-200 bg-slate-50 p-4 shadow-sm">
+                    <header class="flex items-center justify-between">
+                        <h3 class="text-lg font-medium text-slate-800">新生訓練籌備會</h3>
+                        <span class="text-sm text-slate-500">2024/07/15</span>
+                    </header>
+                    <p class="mt-2 text-slate-600">安排新生訓練流程與志工分工，並確認場地動線。</p>
+                    <footer class="mt-3 flex flex-wrap gap-2 text-sm text-slate-500">
+                        <span class="inline-flex items-center gap-1 rounded-full bg-slate-200 px-3 py-1 text-slate-700">#新生事務</span>
+                        <span class="inline-flex items-center gap-1 rounded-full bg-sky-100 px-3 py-1 text-sky-700">#活動規劃</span>
+                    </footer>
+                </article>
+            </div>
+        </section>
+
+        <!-- 六月 -->
+        <section class="bg-white shadow-lg rounded-xl border border-slate-200 overflow-hidden">
+            <div class="bg-amber-600 text-white px-6 py-4">
+                <h2 class="text-2xl font-semibold">六月</h2>
+                <p class="text-amber-100 text-sm mt-1">期末總結</p>
+            </div>
+            <div class="px-6 py-6 space-y-4">
+                <article class="rounded-lg border border-slate-200 bg-slate-50 p-4 shadow-sm">
+                    <header class="flex items-center justify-between">
+                        <h3 class="text-lg font-medium text-slate-800">教評委員會</h3>
+                        <span class="text-sm text-slate-500">2024/06/27</span>
+                    </header>
+                    <p class="mt-2 text-slate-600">檢視本學期教師教學成果並確認獎勵名單。</p>
+                    <footer class="mt-3 flex flex-wrap gap-2 text-sm text-slate-500">
+                        <span class="inline-flex items-center gap-1 rounded-full bg-amber-100 px-3 py-1 text-amber-700">#教學評鑑</span>
+                        <span class="inline-flex items-center gap-1 rounded-full bg-violet-100 px-3 py-1 text-violet-700">#教師發展</span>
+                    </footer>
+                </article>
+            </div>
+        </section>
+
+        <!-- 五月 -->
+        <section class="bg-white shadow-lg rounded-xl border border-slate-200 overflow-hidden">
+            <div class="bg-rose-600 text-white px-6 py-4">
+                <h2 class="text-2xl font-semibold">五月</h2>
+                <p class="text-rose-100 text-sm mt-1">期中重點</p>
+            </div>
+            <div class="px-6 py-6 space-y-4">
+                <article class="rounded-lg border border-slate-200 bg-slate-50 p-4 shadow-sm">
+                    <header class="flex items-center justify-between">
+                        <h3 class="text-lg font-medium text-slate-800">研究倫理審查會</h3>
+                        <span class="text-sm text-slate-500">2024/05/10</span>
+                    </header>
+                    <p class="mt-2 text-slate-600">審核本季研究計畫並更新資料保護指引。</p>
+                    <footer class="mt-3 flex flex-wrap gap-2 text-sm text-slate-500">
+                        <span class="inline-flex items-center gap-1 rounded-full bg-slate-200 px-3 py-1 text-slate-700">#研究倫理</span>
+                        <span class="inline-flex items-center gap-1 rounded-full bg-lime-100 px-3 py-1 text-lime-700">#資料保護</span>
+                    </footer>
+                </article>
+            </div>
+        </section>
+
+        <!-- 四月 -->
+        <section class="bg-white shadow-lg rounded-xl border border-slate-200 overflow-hidden">
+            <div class="bg-teal-600 text-white px-6 py-4">
+                <h2 class="text-2xl font-semibold">四月</h2>
+                <p class="text-teal-100 text-sm mt-1">專案追蹤</p>
+            </div>
+            <div class="px-6 py-6 space-y-4">
+                <article class="rounded-lg border border-slate-200 bg-slate-50 p-4 shadow-sm">
+                    <header class="flex items-center justify-between">
+                        <h3 class="text-lg font-medium text-slate-800">校友交流小組</h3>
+                        <span class="text-sm text-slate-500">2024/04/26</span>
+                    </header>
+                    <p class="mt-2 text-slate-600">擬定校友回娘家活動細節與宣傳策略。</p>
+                    <footer class="mt-3 flex flex-wrap gap-2 text-sm text-slate-500">
+                        <span class="inline-flex items-center gap-1 rounded-full bg-cyan-100 px-3 py-1 text-cyan-700">#校友事務</span>
+                        <span class="inline-flex items-center gap-1 rounded-full bg-amber-100 px-3 py-1 text-amber-700">#活動行銷</span>
+                    </footer>
+                </article>
+            </div>
+        </section>
+
+        <!-- 三月 -->
+        <section class="bg-white shadow-lg rounded-xl border border-slate-200 overflow-hidden">
+            <div class="bg-purple-600 text-white px-6 py-4">
+                <h2 class="text-2xl font-semibold">三月</h2>
+                <p class="text-purple-100 text-sm mt-1">春季議程</p>
+            </div>
+            <div class="px-6 py-6 space-y-4">
+                <article class="rounded-lg border border-slate-200 bg-slate-50 p-4 shadow-sm">
+                    <header class="flex items-center justify-between">
+                        <h3 class="text-lg font-medium text-slate-800">財務審查會議</h3>
+                        <span class="text-sm text-slate-500">2024/03/19</span>
+                    </header>
+                    <p class="mt-2 text-slate-600">檢視第一季財務報表，確認預算編列是否符合規畫。</p>
+                    <footer class="mt-3 flex flex-wrap gap-2 text-sm text-slate-500">
+                        <span class="inline-flex items-center gap-1 rounded-full bg-fuchsia-100 px-3 py-1 text-fuchsia-700">#財務管理</span>
+                        <span class="inline-flex items-center gap-1 rounded-full bg-sky-100 px-3 py-1 text-sky-700">#預算追蹤</span>
+                    </footer>
+                </article>
+            </div>
+        </section>
+
+        <!-- 二月 -->
+        <section class="bg-white shadow-lg rounded-xl border border-slate-200 overflow-hidden">
+            <div class="bg-slate-700 text-white px-6 py-4">
+                <h2 class="text-2xl font-semibold">二月</h2>
+                <p class="text-slate-200 text-sm mt-1">春季開學準備</p>
+            </div>
+            <div class="px-6 py-6 space-y-4">
+                <article class="rounded-lg border border-slate-200 bg-slate-50 p-4 shadow-sm">
+                    <header class="flex items-center justify-between">
+                        <h3 class="text-lg font-medium text-slate-800">人事與行政會議</h3>
+                        <span class="text-sm text-slate-500">2024/02/16</span>
+                    </header>
+                    <p class="mt-2 text-slate-600">確認新學期人力調度與行政支援事項。</p>
+                    <footer class="mt-3 flex flex-wrap gap-2 text-sm text-slate-500">
+                        <span class="inline-flex items-center gap-1 rounded-full bg-slate-200 px-3 py-1 text-slate-700">#行政管理</span>
+                        <span class="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-3 py-1 text-emerald-700">#人力配置</span>
+                    </footer>
+                </article>
+            </div>
+        </section>
+
+        <!-- 一月 -->
+        <section class="bg-white shadow-lg rounded-xl border border-slate-200 overflow-hidden">
+            <div class="bg-neutral-600 text-white px-6 py-4">
+                <h2 class="text-2xl font-semibold">一月</h2>
+                <p class="text-neutral-200 text-sm mt-1">新年開端</p>
+            </div>
+            <div class="px-6 py-6">
+                <p class="text-slate-500">本月會議停開。</p>
+            </div>
+        </section>
+    </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a TailwindCSS-based meeting record list grouped by month from 九月到一月
- include sample meeting cards and placeholders for months without meetings

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d928dbef8883219431fe6b3fc87fcb