### PR TITLE
Add quick month navigation to meeting record search

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,6 +131,16 @@
     <div class="bg-white p-8 rounded-xl shadow-lg w-full max-w-5xl border border-gray-200 mb-8 mt-16 md:mt-4">
         <h1 class="text-3xl font-bold text-gray-800 mb-6 text-center">醫學教育委員會會議紀錄查詢</h1>
 
+        <section id="monthQuickNav" class="mb-6 bg-slate-50 border border-slate-200 rounded-xl p-4 shadow-sm">
+            <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                    <p class="text-xs tracking-wider text-slate-500 uppercase">快速月份導覽</p>
+                    <p id="monthQuickNavYear" class="text-lg font-semibold text-slate-700 mt-1">114 年快速導覽</p>
+                </div>
+                <div id="monthQuickNavButtons" class="grid w-full grid-cols-3 gap-2 sm:w-auto sm:grid-cols-6 md:grid-cols-9"></div>
+            </div>
+        </section>
+
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
             <input type="text" id="keywordInput" placeholder="輸入關鍵字查詢 (例如: 報告, 臨時動議)"
                    class="col-span-1 md:col-span-3 px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
@@ -212,6 +222,13 @@
             const messageContainer = document.getElementById('messageContainer');
             const messageText = document.getElementById('messageText');
             const initialMessage = document.getElementById('initialMessage');
+            const monthQuickNavYearLabel = document.getElementById('monthQuickNavYear');
+            const monthQuickNavButtons = document.getElementById('monthQuickNavButtons');
+            const monthButtonBaseClasses = 'flex cursor-pointer flex-col items-center justify-center gap-1 rounded-lg border border-slate-200 bg-white px-3 py-2 text-center text-slate-600 shadow-sm transition hover:-translate-y-0.5 hover:border-sky-300 hover:bg-sky-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60';
+            let currentNavYear = getDefaultRocYear();
+
+            createMonthButtons(currentNavYear);
+            updateMonthNav(currentNavYear, new Set());
 
             // 登入功能相關元素
             const addMeetingButton = document.getElementById('addMeetingButton');
@@ -259,6 +276,94 @@
                 const escapedKeyword = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
                 const regex = new RegExp(escapedKeyword, 'gi');
                 return text.replace(regex, match => `<span class="highlight">${match}</span>`);
+            }
+
+            function getDefaultRocYear() {
+                const now = new Date();
+                const rocYear = now.getFullYear() - 1911;
+                return rocYear > 0 ? rocYear : now.getFullYear();
+            }
+
+            function createMonthButtons(year) {
+                if (!monthQuickNavButtons) return;
+                monthQuickNavButtons.innerHTML = '';
+                const months = Array.from({ length: 9 }, (_, index) => 9 - index);
+                months.forEach(month => {
+                    const button = document.createElement('button');
+                    button.type = 'button';
+                    button.dataset.month = String(month).padStart(2, '0');
+                    button.className = monthButtonBaseClasses;
+                    button.innerHTML = `
+                        <span class="block text-xs text-slate-500" data-role="year-label">${year} 年</span>
+                        <span class="block text-sm font-semibold text-slate-700">${month} 月</span>
+                    `;
+                    button.addEventListener('click', () => {
+                        if (button.disabled) return;
+                        const target = document.getElementById(`month-${button.dataset.month}`);
+                        if (target) {
+                            target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                        } else {
+                            showMessage('目前查詢結果中尚未有該月份的會議紀錄。', 'info');
+                        }
+                    });
+                    monthQuickNavButtons.appendChild(button);
+                });
+            }
+
+            function updateMonthNav(year, availableMonths = new Set()) {
+                if (!monthQuickNavButtons || !monthQuickNavYearLabel) return;
+                const yearToDisplay = year || getDefaultRocYear();
+                currentNavYear = yearToDisplay;
+                monthQuickNavYearLabel.textContent = `${yearToDisplay} 年快速導覽`;
+                monthQuickNavButtons.querySelectorAll('button').forEach(button => {
+                    const isAvailable = availableMonths.has(button.dataset.month);
+                    button.disabled = !isAvailable;
+                    const yearLabel = button.querySelector('[data-role="year-label"]');
+                    if (yearLabel) {
+                        yearLabel.textContent = `${yearToDisplay} 年`;
+                    }
+                });
+            }
+
+            function toRocYear(date) {
+                if (!(date instanceof Date) || isNaN(date.getTime())) return null;
+                const rocYear = date.getFullYear() - 1911;
+                return rocYear > 0 ? rocYear : null;
+            }
+
+            function parseMeetingDate(rawDate) {
+                if (!rawDate) return null;
+                if (rawDate instanceof Date) {
+                    return isNaN(rawDate.getTime()) ? null : rawDate;
+                }
+
+                const normalized = rawDate
+                    .toString()
+                    .trim()
+                    .replace(/[年月]/g, '/')
+                    .replace(/日/g, '')
+                    .replace(/-/g, '/')
+                    .replace(/\./g, '/');
+
+                const parts = normalized.split(/[\/]/).filter(Boolean);
+                if (parts.length >= 3) {
+                    let year = parseInt(parts[0], 10);
+                    const month = parseInt(parts[1], 10);
+                    const day = parseInt(parts[2], 10);
+
+                    if (!isNaN(year) && !isNaN(month) && !isNaN(day)) {
+                        if (year < 1911) {
+                            year += 1911;
+                        }
+                        const parsedDate = new Date(year, month - 1, day);
+                        if (!isNaN(parsedDate.getTime())) {
+                            return parsedDate;
+                        }
+                    }
+                }
+
+                const fallbackDate = new Date(rawDate);
+                return isNaN(fallbackDate.getTime()) ? null : fallbackDate;
             }
 
             // 格式化日期為 YYYY-MM-DD
@@ -422,9 +527,22 @@
                     if (result.success) {
                         if (result.data && result.data.length > 0) {
                             resultsContainer.innerHTML = '';
+                            const sortedData = [...result.data].sort((a, b) => {
+                                const dateA = parseMeetingDate(a['會議日期']);
+                                const dateB = parseMeetingDate(b['會議日期']);
+                                if (dateA && dateB) {
+                                    return dateB - dateA;
+                                }
+                                if (dateA) return -1;
+                                if (dateB) return 1;
+                                return 0;
+                            });
                             let displayedMeetingsCount = 0;
+                            let highestRocYear = null;
+                            const monthsByYear = new Map();
+                            const meetingCards = [];
 
-                            result.data.forEach(meeting => {
+                            sortedData.forEach(meeting => {
                                 // 判斷是否需要顯示該會議卡片
                                 const shouldDisplayCard = keyword || startDate || endDate;
 
@@ -434,6 +552,22 @@
                                 }
 
                                 displayedMeetingsCount++;
+
+                                const meetingDate = parseMeetingDate(meeting['會議日期']);
+                                const meetingMonth = meetingDate ? String(meetingDate.getMonth() + 1).padStart(2, '0') : null;
+                                const meetingRocYear = meetingDate ? toRocYear(meetingDate) : null;
+
+                                if (meetingRocYear !== null) {
+                                    if (!monthsByYear.has(meetingRocYear)) {
+                                        monthsByYear.set(meetingRocYear, new Set());
+                                    }
+                                    if (meetingMonth) {
+                                        monthsByYear.get(meetingRocYear).add(meetingMonth);
+                                    }
+                                    if (highestRocYear === null || meetingRocYear > highestRocYear) {
+                                        highestRocYear = meetingRocYear;
+                                    }
+                                }
 
                                 const meetingCard = document.createElement('div');
                                 meetingCard.className = 'bg-gray-50 p-6 rounded-lg shadow-sm border border-gray-100 mb-4';
@@ -615,8 +749,33 @@
                                     <p class="text-gray-500 text-sm mt-4"><strong>建立時間:</strong> ${highlightKeyword(formatCreationTime(meeting['建立時間']), keyword)}</p>
                                 `;
                                 meetingCard.innerHTML = cardHtml;
-                                resultsContainer.appendChild(meetingCard);
+                                meetingCards.push({
+                                    element: meetingCard,
+                                    month: meetingMonth,
+                                    rocYear: meetingRocYear
+                                });
                             });
+
+                            const targetYear = highestRocYear !== null ? highestRocYear : currentNavYear;
+                            const availableMonths = monthsByYear.get(targetYear) || new Set();
+                            const monthAnchors = new Set();
+
+                            meetingCards.forEach(({ element, month, rocYear }) => {
+                                if (rocYear === targetYear && month && !monthAnchors.has(month)) {
+                                    const anchor = document.createElement('div');
+                                    anchor.id = `month-${month}`;
+                                    anchor.className = 'block h-0 scroll-mt-24';
+                                    resultsContainer.appendChild(anchor);
+                                    monthAnchors.add(month);
+                                }
+                                resultsContainer.appendChild(element);
+                            });
+
+                            if (displayedMeetingsCount > 0) {
+                                updateMonthNav(targetYear, availableMonths);
+                            } else {
+                                updateMonthNav(currentNavYear, new Set());
+                            }
 
                             resultsContainer.querySelectorAll('.section-header').forEach(header => {
                                 header.addEventListener('click', (event) => {
@@ -643,6 +802,7 @@
 
                         } else {
                             resultsContainer.innerHTML = '<p class="text-gray-500 text-center">沒有找到符合條件的會議紀錄。</p>';
+                            updateMonthNav(currentNavYear, new Set());
                             showMessage('沒有找到符合條件的會議紀錄。', 'info');
                         }
                     } else {


### PR DESCRIPTION
## Summary
- add a Tailwind-styled quick month navigation block under the meeting record search heading
- generate month buttons dynamically and scroll to month anchors while disabling buttons with no matching results
- sort meeting data before rendering, track ROC years, and inject anchors for the latest year's months to support smooth navigation

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d92a272ddc8321bb43b80d402fc8cd